### PR TITLE
Favorites

### DIFF
--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -95,7 +96,9 @@ public class DashboardFragment extends Fragment {
             public void onClick(View v) {
                 Intent i = new Intent(context, EditItineraryActivity.class);
                 startActivity(i);
+                adapter.notifyItemInserted(0);
                 adapter.notifyDataSetChanged();
+//                runThread();
             }
         });
     }
@@ -120,8 +123,24 @@ public class DashboardFragment extends Fragment {
                     // save received posts to list and notify adapter of new data
                     trips.addAll(itineraries);
                     adapter.notifyDataSetChanged();
+//                    runThread();
                 }
             }
         });
     }
+
+//    private void runThread() {
+//        new Thread() {
+//            public void run() {
+//                getActivity().runOnUiThread(new Runnable() {
+//
+//                    @Override
+//                    public void run() {
+//                        adapter.notifyDataSetChanged();
+//                    }
+//                });
+//
+//            }
+//        }.start();
+//    }
 }

--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -16,13 +15,10 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 
 import com.example.fbufinalapp.adapters.ItineraryAdapter;
 import com.example.fbufinalapp.databinding.FragmentDashboardBinding;
 import com.example.fbufinalapp.models.Itinerary;
-import com.google.android.gms.maps.model.Dash;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
@@ -76,7 +72,7 @@ public class DashboardFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        rvItineraries = view.findViewById(R.id.rvItineraries);
+        rvItineraries = view.findViewById(R.id.rvFavorites);
         trips = new ArrayList<>();
         adapter = new ItineraryAdapter(context, trips);
 

--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -98,7 +97,6 @@ public class DashboardFragment extends Fragment {
                 startActivity(i);
                 adapter.notifyItemInserted(0);
                 adapter.notifyDataSetChanged();
-//                runThread();
             }
         });
     }
@@ -123,24 +121,9 @@ public class DashboardFragment extends Fragment {
                     // save received posts to list and notify adapter of new data
                     trips.addAll(itineraries);
                     adapter.notifyDataSetChanged();
-//                    runThread();
                 }
             }
         });
     }
 
-//    private void runThread() {
-//        new Thread() {
-//            public void run() {
-//                getActivity().runOnUiThread(new Runnable() {
-//
-//                    @Override
-//                    public void run() {
-//                        adapter.notifyDataSetChanged();
-//                    }
-//                });
-//
-//            }
-//        }.start();
-//    }
 }

--- a/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
@@ -7,14 +7,11 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.RatingBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.example.fbufinalapp.databinding.ActivityDetailedLocationBinding;
-import com.example.fbufinalapp.databinding.ActivityMainBinding;
-import com.example.fbufinalapp.models.Favorites;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.libraries.places.api.Places;
 import com.google.android.libraries.places.api.model.Place;
@@ -28,18 +25,12 @@ import com.parse.SaveCallback;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class DetailedLocationActivity extends AppCompatActivity {
     public static String TAG = "DetailedLocationActivity";
-//    TextView tvName;
-//    TextView tvAddress;
     TextView tvOpenHours;
     TextView tvPriceLevel;
     RatingBar ratingBar;
-//    Button btWebsite;
-//    Button btPhoneNumber;
-//    Button btDirections;
     PlacesClient placesClient;
     FloatingActionButton fabAddToFav;
     ParseUser currentUser;
@@ -55,14 +46,9 @@ public class DetailedLocationActivity extends AppCompatActivity {
         View view = binding.getRoot();
         setContentView(view);
 
-//        tvName = findViewById(R.id.tvName);
-//        tvAddress = findViewById(R.id.tvAddress);
         tvOpenHours = findViewById(R.id.tvOpenHours);
         tvPriceLevel = findViewById(R.id.tvPriceLevel);
         ratingBar = findViewById(R.id.ratingBar);
-//        btWebsite = findViewById(R.id.btWebsite);
-//        btPhoneNumber = findViewById(R.id.btPhoneNumber);
-//        btDirections = findViewById(R.id.btDirections);
         fabAddToFav = findViewById(R.id.fabAddToFav);
 
         currentUser = ParseUser.getCurrentUser();

--- a/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
@@ -6,11 +6,9 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.example.fbufinalapp.databinding.ActivityDetailedLocationBinding;
 import com.example.fbufinalapp.databinding.ActivityEditItineraryBinding;
 import com.example.fbufinalapp.models.Itinerary;
 import com.google.android.gms.common.api.Status;

--- a/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
@@ -1,15 +1,33 @@
 package com.example.fbufinalapp;
 
+import android.content.Context;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.example.fbufinalapp.adapters.LocationsAdapter;
 import com.example.fbufinalapp.databinding.FragmentDashboardBinding;
 import com.example.fbufinalapp.databinding.FragmentFavoritesBinding;
+import com.google.android.gms.common.api.ApiException;
+import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.model.Place;
+import com.google.android.libraries.places.api.net.FetchPlaceRequest;
+import com.google.android.libraries.places.api.net.PlacesClient;
+import com.parse.ParseUser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -18,6 +36,14 @@ import com.example.fbufinalapp.databinding.FragmentFavoritesBinding;
  */
 public class FavoritesFragment extends Fragment {
     FragmentFavoritesBinding binding;
+    Context context;
+    List<String> favorites;
+    LocationsAdapter adapter;
+    RecyclerView rvFavorites;
+    ParseUser currentUser;
+    public static String TAG = "FavoritesFragment";
+    List<Place.Field> placeFields;
+    PlacesClient placesClient;
 
     public FavoritesFragment() {
         // Required empty public constructor
@@ -38,9 +64,64 @@ public class FavoritesFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
+        context = container.getContext();
         binding = FragmentFavoritesBinding.inflate(getLayoutInflater(), container, false);
         View view = binding.getRoot();
 
         return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        rvFavorites = view.findViewById(R.id.rvFavorites);
+        favorites = new ArrayList<>();
+        adapter = new LocationsAdapter(context, favorites);
+
+        rvFavorites.setAdapter(adapter);
+        rvFavorites.setLayoutManager(new LinearLayoutManager(context));
+
+        currentUser = ParseUser.getCurrentUser();
+
+        placesClient = Places.createClient(context);
+        placeFields = Arrays.asList(Place.Field.ID, Place.Field.NAME, Place.Field.ADDRESS);
+
+        // Setup refresh listener which triggers new data loading
+        binding.swipeContainer.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                // refreshes the user's timeline
+                fetchTimelineAsync(0);
+            }
+        });
+
+        queryFavorites();
+    }
+
+    public void fetchTimelineAsync(int page) {
+        adapter.clear();
+        queryFavorites();
+        binding.swipeContainer.setRefreshing(false);
+    }
+
+    private void queryFavorites(){
+        for (Object fav: currentUser.getList("favorites")) {
+            String placeId = String.valueOf(fav);
+
+            final FetchPlaceRequest request = FetchPlaceRequest.newInstance(placeId, placeFields);
+
+            placesClient.fetchPlace(request).addOnSuccessListener((response) -> {
+                Place place = response.getPlace();
+                String message = place.getName() + "\n" + place.getAddress() + "\n" + placeId;
+                favorites.add(message);
+            }).addOnFailureListener((exception) -> {
+                if (exception instanceof ApiException) {
+                    Log.e(TAG, "Place not found: " + exception.getMessage());
+                }
+            });
+        }
+
+        adapter.notifyDataSetChanged();
     }
 }

--- a/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
@@ -10,15 +10,12 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.example.fbufinalapp.adapters.LocationsAdapter;
-import com.example.fbufinalapp.databinding.FragmentDashboardBinding;
 import com.example.fbufinalapp.databinding.FragmentFavoritesBinding;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.libraries.places.api.Places;
@@ -114,7 +111,7 @@ public class FavoritesFragment extends Fragment {
                 Place place = response.getPlace();
                 String message = place.getName() + "\n" + place.getAddress() + "\n" + placeId;
                 favorites.add(message);
-                favAdapter.notifyItemInserted(favorites.size()-1);
+                favAdapter.notifyItemInserted(0);
             }).addOnFailureListener((exception) -> {
                 if (exception instanceof ApiException) {
                     Log.e(TAG, "Place not found: " + exception.getMessage());
@@ -122,7 +119,7 @@ public class FavoritesFragment extends Fragment {
             });
         }
 
-
+//        favAdapter.notifyDataSetChanged();
     }
 
 

--- a/app/src/main/java/com/example/fbufinalapp/LoginActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/LoginActivity.java
@@ -6,17 +6,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.example.fbufinalapp.databinding.ActivityDetailedLocationBinding;
 import com.example.fbufinalapp.databinding.ActivityLoginBinding;
-import com.parse.LogInCallback;
-import com.parse.ParseException;
 import com.parse.ParseUser;
-
-import org.w3c.dom.Text;
 
 public class LoginActivity extends AppCompatActivity {
     TextView tvUsername;

--- a/app/src/main/java/com/example/fbufinalapp/MainActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/MainActivity.java
@@ -8,17 +8,17 @@ import androidx.fragment.app.FragmentManager;
 import com.example.fbufinalapp.databinding.ActivityMainBinding;
 import com.google.android.libraries.places.api.Places;
 import com.google.android.libraries.places.api.net.PlacesClient;
-import com.parse.Parse;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
-import com.parse.ParseUser;
 
 public class MainActivity extends AppCompatActivity {
+    // define your fragments here
+    Fragment dashboardFragment, searchFragment, favoritesFragment, profileFragment;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -37,12 +37,6 @@ public class MainActivity extends AppCompatActivity {
 
         final FragmentManager fragmentManager = getSupportFragmentManager();
 
-        // define your fragments here
-        final Fragment dashboardFragment = new DashboardFragment();
-        final Fragment searchFragment = new SearchFragment();
-        final Fragment favoritesFragment = new FavoritesFragment();
-        final Fragment profileFragment = new ProfileFragment();
-
         BottomNavigationView bottomNavigationView = (BottomNavigationView) findViewById(R.id.bottom_navigation);
         bottomNavigationView.setOnNavigationItemSelectedListener(
             new BottomNavigationView.OnNavigationItemSelectedListener() {
@@ -51,16 +45,28 @@ public class MainActivity extends AppCompatActivity {
                     Fragment fragment;
                     switch (item.getItemId()) {
                         case R.id.dashboard:
+                            if (dashboardFragment == null){
+                                dashboardFragment = new DashboardFragment();
+                            }
                             fragment = dashboardFragment;
                             break;
                         case R.id.search:
+                            if (searchFragment == null){
+                                searchFragment = new SearchFragment();
+                            }
                             fragment = searchFragment;
                             break;
                         case R.id.favorites:
+                            if (favoritesFragment == null){
+                                favoritesFragment = new FavoritesFragment();
+                            }
                             fragment = favoritesFragment;
                             break;
                         case R.id.profile:
                         default:
+                            if (profileFragment == null){
+                                profileFragment = new ProfileFragment();
+                            }
                             fragment = profileFragment;
                             break;
                     }

--- a/app/src/main/java/com/example/fbufinalapp/ProfileFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/ProfileFragment.java
@@ -11,10 +11,7 @@ import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
-import android.widget.TextView;
 
-import com.example.fbufinalapp.databinding.FragmentDashboardBinding;
 import com.example.fbufinalapp.databinding.FragmentProfileBinding;
 import com.parse.ParseUser;
 

--- a/app/src/main/java/com/example/fbufinalapp/SearchFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/SearchFragment.java
@@ -1,7 +1,6 @@
 package com.example.fbufinalapp;
 
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -12,38 +11,23 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
-import android.widget.TextView;
 import android.widget.Toast;
 
-import com.example.fbufinalapp.adapters.ItineraryAdapter;
 import com.example.fbufinalapp.adapters.LocationsAdapter;
-import com.example.fbufinalapp.databinding.FragmentDashboardBinding;
 import com.example.fbufinalapp.databinding.FragmentSearchBinding;
-import com.example.fbufinalapp.models.Itinerary;
 import com.google.android.gms.common.api.ApiException;
-import com.google.android.gms.common.api.Status;
 import com.google.android.libraries.places.api.Places;
 import com.google.android.libraries.places.api.model.AutocompletePrediction;
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken;
-import com.google.android.libraries.places.api.model.Place;
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest;
 import com.google.android.libraries.places.api.net.PlacesClient;
-import com.google.android.libraries.places.widget.Autocomplete;
-import com.google.android.libraries.places.widget.AutocompleteSupportFragment;
-import com.google.android.libraries.places.widget.listener.PlaceSelectionListener;
-import com.google.android.libraries.places.widget.model.AutocompleteActivityMode;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-
-import static android.app.Activity.RESULT_OK;
-import static android.app.Activity.RESULT_CANCELED;
 
 /**
  * A simple {@link Fragment} subclass.

--- a/app/src/main/java/com/example/fbufinalapp/SignUpActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/SignUpActivity.java
@@ -6,15 +6,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.example.fbufinalapp.databinding.ActivityDetailedLocationBinding;
 import com.example.fbufinalapp.databinding.ActivitySignUpBinding;
-import com.parse.ParseException;
 import com.parse.ParseUser;
-import com.parse.SignUpCallback;
 
 public class SignUpActivity extends AppCompatActivity {
     TextView tvUsername;

--- a/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
@@ -1,25 +1,17 @@
 package com.example.fbufinalapp.adapters;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.fbufinalapp.R;
 import com.example.fbufinalapp.models.Itinerary;
-import com.google.android.gms.common.api.ApiException;
-import com.google.android.libraries.places.api.Places;
-import com.google.android.libraries.places.api.model.Place;
-import com.google.android.libraries.places.api.net.FetchPlaceRequest;
-import com.google.android.libraries.places.api.net.PlacesClient;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 

--- a/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
@@ -58,6 +58,14 @@ public class ItineraryAdapter extends RecyclerView.Adapter<ItineraryAdapter.View
         notifyDataSetChanged();
     }
 
+    public List<Itinerary> getItems() {
+        return itins;
+    }
+
+    public void setItems(List<Itinerary> newItins) {
+        itins = newItins;
+    }
+
     class ViewHolder extends RecyclerView.ViewHolder {
         TextView tvTitle;
         TextView tvDates;

--- a/app/src/main/java/com/example/fbufinalapp/adapters/LocationsAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/LocationsAdapter.java
@@ -2,30 +2,18 @@ package com.example.fbufinalapp.adapters;
 
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.fbufinalapp.DetailedLocationActivity;
 import com.example.fbufinalapp.R;
-import com.example.fbufinalapp.models.Itinerary;
-import com.google.android.gms.common.api.ApiException;
-import com.google.android.libraries.places.api.Places;
-import com.google.android.libraries.places.api.model.AutocompletePrediction;
-import com.google.android.libraries.places.api.model.AutocompleteSessionToken;
-import com.google.android.libraries.places.api.model.Place;
-import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest;
-import com.google.android.libraries.places.api.net.PlacesClient;
 
-import java.util.Date;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class LocationsAdapter extends RecyclerView.Adapter<LocationsAdapter.ViewHolder>{
 

--- a/app/src/main/java/com/example/fbufinalapp/adapters/LocationsAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/LocationsAdapter.java
@@ -56,6 +56,11 @@ public class LocationsAdapter extends RecyclerView.Adapter<LocationsAdapter.View
         return places.size();
     }
 
+    public void clear() {
+        places.clear();
+        notifyDataSetChanged();
+    }
+
     class ViewHolder extends RecyclerView.ViewHolder {
         TextView tvPrimary;
         TextView tvSecondary;

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -43,5 +43,5 @@
         android:layout_marginBottom="70dp"
         android:clickable="true"
         android:src="@android:drawable/ic_menu_add"
-        app:backgroundTint="?attr/colorButtonNormal" />
+        app:backgroundTint="@color/brown_light" />
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -24,7 +24,7 @@
         android:layout_below="@+id/tvPageTitle">
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rvItineraries"
+            android:id="@+id/rvFavorites"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -1,14 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".FavoritesFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
+        android:id="@+id/tvPageTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="20dp"
+        android:text="Your Favorited Locations"
+        android:textSize="24sp" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:layout_below="@+id/tvPageTitle">
 
-</FrameLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvFavorites"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_alignParentStart="true"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="5dp"
+            android:padding="10dp" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -12,7 +12,7 @@
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="20dp"
-        android:text="Your Favorited Locations"
+        android:text="Your Favorite Locations"
         android:textSize="24sp" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout


### PR DESCRIPTION
[Bugfix + chore] : fixed issue of RecyclerView not loading items on the Favorites page

Summary: when the user landed on their Favorites page, they were not able to see their current favorites in the RecyclerView. In order to see the list, they had to interact with the page in some way (click/scroll). This PR fixes that problem and cleans the code to reduce lag.

Changes in this PR: 
- The favorites adapter is updated with every new addition added to the list, rather than at the end of the queryFavorites() function
- Miscellaneous/unnecessary imports were removed from all files to help reduce lag
- Fragments are no longer initialized all at once, which may also cause more lag; they are created as they are needed by the user (i.e. on click on the bottom navigation). 

Follow ups:
- There is still a second or two of delay while loading RecyclerViews; may be caused by the API/SDK calls. Open to suggestions on what to try :)