### PR TITLE
Itineraries

### DIFF
--- a/app/src/main/java/com/example/fbufinalapp/CommonFunctions.java
+++ b/app/src/main/java/com/example/fbufinalapp/CommonFunctions.java
@@ -1,0 +1,47 @@
+package com.example.fbufinalapp;
+
+import android.content.Context;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.model.Place;
+import com.google.android.libraries.places.api.net.FetchPlaceRequest;
+import com.google.android.libraries.places.api.net.PlacesClient;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CommonFunctions {
+    static Place place;
+
+    public static Place getPlace(String placeId, Context context) {
+        PlacesClient placesClient = Places.createClient(context);
+
+        // Specify the fields to return.
+        List<Place.Field> placeFields = Arrays.asList(Place.Field.ID,
+                Place.Field.NAME, Place.Field.ADDRESS, Place.Field.RATING, Place.Field.PRICE_LEVEL,
+                Place.Field.WEBSITE_URI, Place.Field.PHONE_NUMBER);
+
+        // Construct a request object, passing the place ID and fields array.
+        FetchPlaceRequest request = FetchPlaceRequest.newInstance(placeId, placeFields);
+
+        placesClient.fetchPlace(request).addOnSuccessListener((response) -> {
+            setPlace(response.getPlace());
+            Log.i("CommonFunctions", "inside: " + String.valueOf(place));
+        }).addOnFailureListener((exception) -> {
+            Log.e("CommonFunctions", String.valueOf(exception));
+            Toast.makeText(context, "Error retrieving location", Toast.LENGTH_SHORT).show();
+        });
+
+        Log.i("CommonFunctions", "outside: " + String.valueOf(place));
+        return place;
+
+    }
+
+    public static void setPlace(Place placeFound){
+        place = placeFound;
+        Log.i("CommonFunctions", "setting: " + String.valueOf(place));
+    }
+
+}

--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -26,6 +26,7 @@ import com.example.fbufinalapp.models.Itinerary;
 import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
+import com.parse.ParseUser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -149,6 +150,8 @@ public class DashboardFragment extends Fragment {
     private void queryPosts() {
         ParseQuery<Itinerary> query = ParseQuery.getQuery(Itinerary.class);
         query.include(Itinerary.KEY_USER);
+        query.whereEqualTo("authors", ParseUser.getCurrentUser());
+
         // order posts by creation date (newest first)
         query.addDescendingOrder("createdAt");
         query.findInBackground(new FindCallback<Itinerary>() {

--- a/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
@@ -68,6 +68,7 @@ public class DetailedItineraryActivity extends AppCompatActivity {
             if (e == null) {
                 currentItinerary = object;
                 binding.tvTitle.setText(object.getTitle());
+                getSupportActionBar().setTitle(object.getTitle());
                 getDestinations();
 
                 rvDestinations = view.findViewById(R.id.rvDestinations);

--- a/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
@@ -85,7 +85,6 @@ public class DetailedLocationActivity extends AppCompatActivity {
         pw.setContentView(layout);
         pw.setWidth((int) (screenWidth*0.9));
         pw.setOutsideTouchable(true);
-//        pw.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
 
         placeId = getIntent().getStringExtra("placeID");
         String name = getIntent().getStringExtra("name");
@@ -181,6 +180,9 @@ public class DetailedLocationActivity extends AppCompatActivity {
 
         placesClient.fetchPlace(request).addOnSuccessListener((response) -> {
             place = response.getPlace();
+
+            Log.i("DetailedLocation", String.valueOf(place));
+
             binding.tvName.setText(place.getName());
             binding.tvAddress.setText(place.getAddress());
 
@@ -255,6 +257,9 @@ public class DetailedLocationActivity extends AppCompatActivity {
                 Log.e(TAG, "Place not found: " + exception.getMessage());
             }
         });
+
+
+
     }
 
     public void getAllItins(){

--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -93,6 +93,15 @@ public class EditDestinationActivity extends AppCompatActivity {
                 query.getInBackground(getIntent().getStringExtra("destinationId"), (object, e) -> {
                     if (e == null) {
                         editingDestination = object;
+                        Date date = editingDestination.getDate();
+
+                        SimpleDateFormat dateFormatter = new SimpleDateFormat("MMM dd, yyyy");
+                        SimpleDateFormat timeFormatter = new SimpleDateFormat("hh:mm");
+                        SimpleDateFormat amPMFormatter = new SimpleDateFormat("a");
+
+                        binding.etDateSelect.setText(dateFormatter.format(date));
+                        binding.etTime.setText(timeFormatter.format(date));
+                        binding.etTimeSelect.setText(amPMFormatter.format(date));
                     } else {
                         // something went wrong
                         Toast.makeText(this, "Couldn't retrieve destination", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/example/fbufinalapp/LoginActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/LoginActivity.java
@@ -26,6 +26,8 @@ public class LoginActivity extends AppCompatActivity {
         View view = binding.getRoot();
         setContentView(view);
 
+        getSupportActionBar().setTitle("Login");
+
         tvUsername = findViewById(R.id.tvUsername);
         tvPassword = findViewById(R.id.tvPassword);
 

--- a/app/src/main/java/com/example/fbufinalapp/MainActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/MainActivity.java
@@ -7,17 +7,26 @@ import androidx.fragment.app.FragmentManager;
 
 import com.example.fbufinalapp.databinding.ActivityMainBinding;
 import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.model.Place;
+import com.google.android.libraries.places.api.net.FetchPlaceRequest;
 import com.google.android.libraries.places.api.net.PlacesClient;
 
+import android.content.Context;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Toast;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
     // define your fragments here
     Fragment dashboardFragment, searchFragment, favoritesFragment, profileFragment;
+    static Place place;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,9 +40,6 @@ public class MainActivity extends AppCompatActivity {
 
         // Initialize the SDK
         Places.initialize(getApplicationContext(), getResources().getString(R.string.apiKey));
-
-        // Create a new PlacesClient instance
-        PlacesClient placesClient = Places.createClient(this);
 
         final FragmentManager fragmentManager = getSupportFragmentManager();
 
@@ -80,5 +86,29 @@ public class MainActivity extends AppCompatActivity {
 
     public void setActionBarTitle(String title) {
         getSupportActionBar().setTitle(title);
+    }
+
+    public static Place getPlace(String placeId, Context context) {
+        PlacesClient placesClient = Places.createClient(context);
+
+        // Specify the fields to return.
+        List<Place.Field> placeFields = Arrays.asList(Place.Field.ID,
+                Place.Field.NAME, Place.Field.ADDRESS, Place.Field.RATING, Place.Field.PRICE_LEVEL,
+                Place.Field.WEBSITE_URI, Place.Field.PHONE_NUMBER);
+
+        // Construct a request object, passing the place ID and fields array.
+        FetchPlaceRequest request = FetchPlaceRequest.newInstance(placeId, placeFields);
+
+        placesClient.fetchPlace(request).addOnSuccessListener((response) -> {
+            place = response.getPlace();
+            Log.i("CommonFunctions", "inside: " + String.valueOf(place));
+        }).addOnFailureListener((exception) -> {
+            Log.e("CommonFunctions", String.valueOf(exception));
+            Toast.makeText(context, "Error retrieving location", Toast.LENGTH_SHORT).show();
+        });
+
+        Log.i("CommonFunctions", "outside: " + String.valueOf(place));
+        return place;
+
     }
 }

--- a/app/src/main/java/com/example/fbufinalapp/SignUpActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/SignUpActivity.java
@@ -12,6 +12,8 @@ import android.widget.Toast;
 import com.example.fbufinalapp.databinding.ActivitySignUpBinding;
 import com.parse.ParseUser;
 
+import java.util.ArrayList;
+
 public class SignUpActivity extends AppCompatActivity {
     TextView tvUsername;
     TextView tvPassword;
@@ -26,6 +28,8 @@ public class SignUpActivity extends AppCompatActivity {
         // layout of activity is stored in a special property called root
         View view = binding.getRoot();
         setContentView(view);
+
+        getSupportActionBar().setTitle("Register");
 
         tvUsername = findViewById(R.id.tvUsername);
         tvPassword = findViewById(R.id.tvPassword);
@@ -48,6 +52,8 @@ public class SignUpActivity extends AppCompatActivity {
         user.setUsername(username);
         user.setPassword(password);
         user.setEmail(email);
+        user.put("favorites", new ArrayList<>());
+        user.put("itineraries", new ArrayList<>());
 
         user.signUpInBackground(e -> {
             if (e == null) {

--- a/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
@@ -81,9 +81,10 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
             itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (DetailedItineraryActivity.getEditing()) {
+                    Destination desti = destinations.get(getAdapterPosition());
+
+                    if (DetailedItineraryActivity.getEditing() && !desti.getIsDay()) {
                         Intent i = new Intent(context, EditDestinationActivity.class);
-                        Destination desti = destinations.get(getAdapterPosition());
                         i.putExtra("itinId", currentItin.getObjectId());
                         i.putExtra("placeId", desti.getPlaceID());
                         i.putExtra("editing", true);
@@ -99,10 +100,13 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
                 public boolean onLongClick(View view) {
                     int position = getAdapterPosition();
                     Destination deleted = destinations.get(position);
-                    destinations.remove(position);
-                    notifyItemRemoved(position);
 
-                    showUndoSnackbar(position, deleted);
+                    if (!deleted.getIsDay()) {
+                        destinations.remove(position);
+                        notifyItemRemoved(position);
+
+                        showUndoSnackbar(position, deleted);
+                    }
 
                     return true;
                 }
@@ -117,35 +121,35 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
             snackbar.addCallback(new Snackbar.Callback() {
                 @Override
                 public void onDismissed(Snackbar transientBottomBar, int event) {
-                    super.onDismissed(transientBottomBar, event);
+                super.onDismissed(transientBottomBar, event);
 
-                    if (event == BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_SWIPE || event == BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_TIMEOUT){
-                        // the snackbar disappears by itself; the user doesn't want to undo the deletion
-                        List<String> destIds = new ArrayList<>();
-                        for (Destination i : destinations){
-                            destIds.add(i.getObjectId());
-                        }
-                        currentItin.put("destinations", destIds);
-
-                        currentItin.saveInBackground(e -> {
-                            if(e!=null){
-                                Toast.makeText(context, "Unable to delete destination", Toast.LENGTH_SHORT).show();
-                            } else {
-                                ParseQuery<Destination> query = ParseQuery.getQuery("Destination");
-                                query.getInBackground(deleted.getObjectId(), (object, e2) -> {
-                                    if (e2 == null) {
-                                        object.deleteInBackground(e3 -> {
-                                            if(e2!=null){
-                                                Toast.makeText(context, "Unable to delete destination", Toast.LENGTH_SHORT).show();
-                                            }
-                                        });
-                                    }else{
-                                        Toast.makeText(context, "Unable to delete destination", Toast.LENGTH_SHORT).show();
-                                    }
-                                });
-                            }
-                        });
+                if (event != BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_ACTION){
+                    // the snackbar disappears by itself; the user doesn't want to undo the deletion
+                    List<String> destIds = new ArrayList<>();
+                    for (Destination i : destinations){
+                        destIds.add(i.getObjectId());
                     }
+                    currentItin.put("destinations", destIds);
+
+                    currentItin.saveInBackground(e -> {
+                        if(e!=null){
+                            Toast.makeText(context, "Unable to delete destination", Toast.LENGTH_SHORT).show();
+                        } else {
+                            ParseQuery<Destination> query = ParseQuery.getQuery("Destination");
+                            query.getInBackground(deleted.getObjectId(), (object, e2) -> {
+                                if (e2 == null) {
+                                    object.deleteInBackground(e3 -> {
+                                        if(e2!=null){
+                                            Toast.makeText(context, "Unable to delete destination", Toast.LENGTH_SHORT).show();
+                                        }
+                                    });
+                                }else{
+                                    Toast.makeText(context, "Unable to delete destination", Toast.LENGTH_SHORT).show();
+                                }
+                            });
+                        }
+                    });
+                }
                 }
             });
 

--- a/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.fbufinalapp.DetailedItineraryActivity;
+import com.example.fbufinalapp.DetailedLocationActivity;
 import com.example.fbufinalapp.EditDestinationActivity;
 import com.example.fbufinalapp.R;
 import com.example.fbufinalapp.models.Destination;
@@ -90,6 +91,11 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
                         i.putExtra("editing", true);
                         i.putExtra("destinationId", desti.getObjectId());
 
+                        context.startActivity(i);
+                    } else if (!DetailedItineraryActivity.getEditing() && !desti.getIsDay()) {
+                        Intent i = new Intent(context, DetailedLocationActivity.class);
+                        i.putExtra("placeID", desti.getPlaceID());
+                        i.putExtra("name", tvName.getText());
                         context.startActivity(i);
                     }
                 }

--- a/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
@@ -18,6 +18,7 @@ import com.example.fbufinalapp.DetailedItineraryActivity;
 import com.example.fbufinalapp.EditItineraryActivity;
 import com.example.fbufinalapp.R;
 import com.example.fbufinalapp.models.Itinerary;
+import com.google.android.material.snackbar.BaseTransientBottomBar;
 import com.google.android.material.snackbar.Snackbar;
 import com.parse.ParseQuery;
 import com.parse.ParseUser;
@@ -123,8 +124,9 @@ public class ItineraryAdapter extends RecyclerView.Adapter<ItineraryAdapter.View
             snackbar.addCallback(new Snackbar.Callback() {
                 @Override
                 public void onDismissed(Snackbar transientBottomBar, int event) {
-                    super.onDismissed(transientBottomBar, event);
-                    // the snackbar disappears by itself; the user doesn't want to undo the deletion
+                super.onDismissed(transientBottomBar, event);
+                // the snackbar disappears by itself; the user doesn't want to undo the deletion
+                if (event != BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_ACTION) {
                     List<String> itinIds = new ArrayList<>();
                     for (Itinerary i : itins){
                         itinIds.add(i.getObjectId());
@@ -150,6 +152,8 @@ public class ItineraryAdapter extends RecyclerView.Adapter<ItineraryAdapter.View
                             });
                         }
                     });
+                }
+
                 }
             });
 

--- a/app/src/main/res/layout/activity_edit_destination.xml
+++ b/app/src/main/res/layout/activity_edit_destination.xml
@@ -140,8 +140,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/etTime"
-        android:layout_alignParentBottom="false"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="350dp"
+        android:layout_marginTop="300dp"
         android:text="Save Trip" />
 </RelativeLayout>


### PR DESCRIPTION
[bugfixes] : misc bug fixes to improve ux 

Summary: users were previously able to edit/delete day markers, which would then crash the app. Editing destinations/itineraries would also not show all previous information in the form fields. Also, when registering, users would not be given an empty favorites list, which would then cause the app to crash when they try to access their favorites page. This PR fixes these problems.

Changes in this PR:
- Destinations onclick will first check if the item being selected is a day marker, and only fire the onclick method if the item is a destination created by the user.
- Similar change to onLongClick; the method is only fired when the user is selecting a user-made destination, so they cannot delete the day markers
- When registering for an account, the user is also initialized with an empty list for their favorites and for their itineraries, so the app will not crash when trying to access a null variable