### PR TITLE
user can add personal destinations

### DIFF
--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -43,6 +43,7 @@ public class EditDestinationActivity extends AppCompatActivity {
     String timeSelected;
     Place place;
     Itinerary currentItinerary;
+    ActivityEditDestinationBinding binding;
     Destination editingDestination;
     TextView tvLocation;
     boolean editing = false;
@@ -52,7 +53,7 @@ public class EditDestinationActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         // using view binding
-        ActivityEditDestinationBinding binding = ActivityEditDestinationBinding.inflate(getLayoutInflater());
+        binding = ActivityEditDestinationBinding.inflate(getLayoutInflater());
 
         // layout of activity is stored in a special property called root
         View view = binding.getRoot();
@@ -69,23 +70,24 @@ public class EditDestinationActivity extends AppCompatActivity {
 
             tvLocation.setFocusable(false);
 
-            // Specify the fields to return.
-            final List<Place.Field> placeFields = Arrays.asList(Place.Field.ID, Place.Field.NAME);
+            if (placeId != null){
+                // Specify the fields to return.
+                final List<Place.Field> placeFields = Arrays.asList(Place.Field.ID, Place.Field.NAME);
 
-            // Construct a request object, passing the place ID and fields array.
-            final FetchPlaceRequest request = FetchPlaceRequest.newInstance(placeId, placeFields);
+                // Construct a request object, passing the place ID and fields array.
+                final FetchPlaceRequest request = FetchPlaceRequest.newInstance(placeId, placeFields);
 
-            PlacesClient placesClient = Places.createClient(EditDestinationActivity.this);
+                PlacesClient placesClient = Places.createClient(EditDestinationActivity.this);
 
-            placesClient.fetchPlace(request).addOnSuccessListener((response) -> {
-                place = response.getPlace();
-                tvLocation.setText(place.getName());
-            }).addOnFailureListener((exception) -> {
-                if (exception instanceof ApiException) {
-                    final ApiException apiException = (ApiException) exception;
-                    Toast.makeText(EditDestinationActivity.this, "Error retrieving location", Toast.LENGTH_SHORT).show();
-                }
-            });
+                placesClient.fetchPlace(request).addOnSuccessListener((response) -> {
+                    place = response.getPlace();
+                    tvLocation.setText(place.getName());
+                }).addOnFailureListener((exception) -> {
+                    if (exception instanceof ApiException) {
+                        Toast.makeText(EditDestinationActivity.this, "Error retrieving location", Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
 
             if (getIntent().hasExtra("editing")){
                 editing = true;
@@ -104,6 +106,7 @@ public class EditDestinationActivity extends AppCompatActivity {
                         binding.etDateSelect.setText(dateFormatter.format(date));
                         binding.etTime.setText(timeFormatter.format(date));
                         binding.etTimeSelect.setText(amPMFormatter.format(date));
+                        binding.etDestName.setText(object.getName());
                     } else {
                         // something went wrong
                         Toast.makeText(this, "Couldn't retrieve destination", Toast.LENGTH_SHORT).show();
@@ -168,7 +171,10 @@ public class EditDestinationActivity extends AppCompatActivity {
                     destination = new Destination();
                 }
 
-                destination.setPlaceID(place.getId());
+                if (place != null) {
+                    destination.setPlaceID(place.getId());
+                }
+
                 destination.setItinerary(currentItinerary);
 
                 SimpleDateFormat timezoneFormat = new SimpleDateFormat("zzzz");
@@ -183,7 +189,7 @@ public class EditDestinationActivity extends AppCompatActivity {
                     e.printStackTrace();
                 }
                 destination.setIsDay(false);
-                destination.setName(String.valueOf(binding.tvLocation.getText()));
+                destination.setName(String.valueOf(binding.etDestName.getText()));
 
                 destination.saveInBackground(new SaveCallback() {
                     @Override
@@ -241,7 +247,11 @@ public class EditDestinationActivity extends AppCompatActivity {
             if (resultCode == RESULT_OK) {
                 Place location = Autocomplete.getPlaceFromIntent(data);
                 place = location;
-                tvLocation.setText(place.getName());
+                String name = place.getName();
+                tvLocation.setText(name);
+                if (String.valueOf(binding.etDestName.getText()).equals("")) {
+                    binding.etDestName.setText(name);
+                }
             } else {
                 Status status = Autocomplete.getStatusFromIntent(data);
             }

--- a/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
@@ -91,7 +91,7 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
                         i.putExtra("destinationId", desti.getObjectId());
 
                         context.startActivity(i);
-                    } else if (!DetailedItineraryActivity.getEditing() && !desti.getIsDay()) {
+                    } else if (!DetailedItineraryActivity.getEditing() && !desti.getIsDay() && desti.getPlaceID() != null) {
                         Intent i = new Intent(context, DetailedLocationActivity.class);
                         i.putExtra("placeID", desti.getPlaceID());
                         i.putExtra("name", tvName.getText());

--- a/app/src/main/java/com/example/fbufinalapp/models/Destination.java
+++ b/app/src/main/java/com/example/fbufinalapp/models/Destination.java
@@ -1,10 +1,20 @@
 package com.example.fbufinalapp.models;
 
+import android.content.Context;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.google.android.libraries.places.api.Places;
+import com.google.android.libraries.places.api.model.Place;
+import com.google.android.libraries.places.api.net.FetchPlaceRequest;
+import com.google.android.libraries.places.api.net.PlacesClient;
 import com.parse.ParseClassName;
 import com.parse.ParseObject;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 /**
  * ParseObject class to access destination data from Parse backend. Parse models initialized in

--- a/app/src/main/res/layout/activity_edit_destination.xml
+++ b/app/src/main/res/layout/activity_edit_destination.xml
@@ -42,7 +42,7 @@
         android:id="@+id/tvLocPrompt"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/tvTrip"
+        android:layout_below="@+id/tvDestName"
         android:layout_alignParentStart="true"
         android:layout_marginStart="15dp"
         android:layout_marginTop="20dp"
@@ -53,9 +53,9 @@
         android:id="@+id/tvLocation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/tvTripName"
+        android:layout_below="@+id/etDestName"
         android:layout_marginStart="10dp"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="5dp"
         android:layout_marginEnd="10dp"
         android:layout_toEndOf="@+id/tvLocPrompt"
         android:ems="10"
@@ -143,4 +143,28 @@
         android:layout_centerHorizontal="true"
         android:layout_marginTop="300dp"
         android:text="Save Trip" />
+
+    <TextView
+        android:id="@+id/tvDestName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvTrip"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentBottom="false"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="15dp"
+        android:text="Name:"
+        android:textSize="20sp" />
+
+    <EditText
+        android:id="@+id/etDestName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvTripName"
+        android:layout_alignParentEnd="true"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="10dp"
+        android:layout_toEndOf="@+id/tvDestName"
+        android:ems="10" />
 </RelativeLayout>


### PR DESCRIPTION
[feature] Added functionality to let the user create their own destinations without needing a location.

Summary: Previously, the user was restricted to adding a location to every destination, and they couldn't add their own name to it. In this PR, I changed it so that there is now an option for them to input a name.

Changes in this PR:
- The user can input a name for a new destination, and this name is what is displayed in the itinerary page.
- If a name is not given, the name of the location given is used instead.
- The user no longer has to input a location.

Callouts/Follow-up:
- If the user inputs both a name and a location, the name of the location is no longer displayed on the itinerary page. This might be confusing and/or inconvenient for the user, so I may need to rearrange/add some stuff in item_destination.xml