### PR TITLE
Itineraries

### DIFF
--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -105,9 +105,9 @@ public class EditDestinationActivity extends AppCompatActivity {
 
                         dateSelected = dateFormatter.format(date);
                         timeSelected = amPMFormatter.format(date);
-                        binding.etDateSelect.setText(dateSelected);
+                        binding.etDateSelect.setHint(dateSelected);
                         binding.etTime.setText(timeFormatter.format(date));
-                        binding.etTimeSelect.setText(timeSelected);
+                        binding.etTimeSelect.setHint(timeSelected);
                         binding.etDestName.setText(object.getName());
                     } else {
                         // something went wrong

--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -103,9 +103,11 @@ public class EditDestinationActivity extends AppCompatActivity {
                         SimpleDateFormat timeFormatter = new SimpleDateFormat("hh:mm");
                         SimpleDateFormat amPMFormatter = new SimpleDateFormat("a");
 
-                        binding.etDateSelect.setText(dateFormatter.format(date));
+                        dateSelected = dateFormatter.format(date);
+                        timeSelected = amPMFormatter.format(date);
+                        binding.etDateSelect.setText(dateSelected);
                         binding.etTime.setText(timeFormatter.format(date));
-                        binding.etTimeSelect.setText(amPMFormatter.format(date));
+                        binding.etTimeSelect.setText(timeSelected);
                         binding.etDestName.setText(object.getName());
                     } else {
                         // something went wrong

--- a/app/src/main/res/layout/activity_edit_destination.xml
+++ b/app/src/main/res/layout/activity_edit_destination.xml
@@ -55,7 +55,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/etDestName"
         android:layout_marginStart="10dp"
-        android:layout_marginTop="5dp"
+        android:layout_marginTop="2dp"
         android:layout_marginEnd="10dp"
         android:layout_toEndOf="@+id/tvLocPrompt"
         android:ems="10"
@@ -80,7 +80,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/tvLocation"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_toEndOf="@+id/tvDatePrompt">
 
@@ -88,7 +88,6 @@
             android:id="@+id/etDateSelect"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Select a date"
             android:inputType="none" />
 
     </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
[bugfixes] : correct bug fixes that prevented the user from successfully editing destinations

Summary: previously, editing destinations caused errors where the dropdown menus did not show all the correct values. This PR fixes the bugs so that the destinations can now be edited successfully.

Changes in this PR:
- Destinations while editing returned null for some date values, which prevented the destination from being edited. On edit, these values are given the correct default values so that they don't become null later.
- The hint was removed from the spinners so that all values can be shown while editing.

Callouts/Follow-ups:
- I removed the hints/setText() from the spinner since that was preventing the dropdown from showing while editing, but there is probably a better solution somewhere. Look into this while moving on!