### PR TITLE
Itineraries

### DIFF
--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -184,12 +184,18 @@ public class EditDestinationActivity extends AppCompatActivity {
                 String timeString = dateSelected + " " + binding.etTime.getText() + " " + timeSelected + " " + timezoneFormat.format(new Date());
                 SimpleDateFormat formatter = new SimpleDateFormat("MMM dd, yyyy hh:mm a zzzz");
 
+                boolean timeValid = true;
                 try {
-                    destination.setDate(formatter.parse(timeString));
+                    Date selectedDate = formatter.parse(timeString);
+                    if (place.isOpen(selectedDate.getTime())){
+                        destination.setDate(selectedDate);
+                    } else {
+                        timeValid = false;
+                    }
                 } catch (java.text.ParseException e) {
-                    Log.e("EditDestination", String.valueOf(e));
                     e.printStackTrace();
                 }
+
                 destination.setIsDay(false);
 
                 String placeName = place.getName();
@@ -200,35 +206,39 @@ public class EditDestinationActivity extends AppCompatActivity {
                     destination.setName(inputtedName + "\n" + placeName);
                 }
 
+                if (timeValid){
+                    destination.saveInBackground(new SaveCallback() {
+                        @Override
+                        public void done(ParseException e) {
+                            if (e == null){
+                                binding.tvTripName.setText("");
+                                tvLocation.setText("");
+                                binding.etDateSelect.setText("");
+                                binding.etTime.setText("");
 
-                destination.saveInBackground(new SaveCallback() {
-                    @Override
-                    public void done(ParseException e) {
-                        if (e == null){
-                            binding.tvTripName.setText("");
-                            tvLocation.setText("");
-                            binding.etDateSelect.setText("");
-                            binding.etTime.setText("");
+                                if (!editing) {
+                                    queryItinerary.getInBackground(itinId, (object, error) -> {
+                                        if (error != null){
+                                            Toast.makeText(EditDestinationActivity.this, "Couldn't save destination", Toast.LENGTH_SHORT).show();
+                                        } else {
+                                            List<String> currentDests = object.getDestinations();
+                                            currentDests.add(destination.getObjectId());
+                                            object.put("destinations", currentDests);
 
-                            if (!editing) {
-                                queryItinerary.getInBackground(itinId, (object, error) -> {
-                                    if (error != null){
-                                        Toast.makeText(EditDestinationActivity.this, "Couldn't save destination", Toast.LENGTH_SHORT).show();
-                                    } else {
-                                        List<String> currentDests = object.getDestinations();
-                                        currentDests.add(destination.getObjectId());
-                                        object.put("destinations", currentDests);
-
-                                        object.saveInBackground();
-                                    }
-                                });
+                                            object.saveInBackground();
+                                        }
+                                    });
+                                }
+                            } else {
+                                Toast.makeText(EditDestinationActivity.this, "Couldn't save destination", Toast.LENGTH_SHORT).show();
                             }
-                        } else {
-                            Toast.makeText(EditDestinationActivity.this, "Couldn't save destination", Toast.LENGTH_SHORT).show();
                         }
-                    }
-                });
-                finish();
+                    });
+                    finish();
+                } else {
+                    Toast.makeText(EditDestinationActivity.this, "This location won't be open at that time.", Toast.LENGTH_SHORT).show();
+                }
+
             }
         });
 
@@ -242,7 +252,8 @@ public class EditDestinationActivity extends AppCompatActivity {
         @Override
         public void onFocusChange(View v, boolean hasFocus) {
             if (hasFocus){
-                List<Place.Field> fields = Arrays.asList(Place.Field.ID, Place.Field.NAME);
+                List<Place.Field> fields = Arrays.asList(Place.Field.ID, Place.Field.NAME,
+                        Place.Field.OPENING_HOURS, Place.Field.UTC_OFFSET);
 
                 Intent intent = new Autocomplete.IntentBuilder(AutocompleteActivityMode.FULLSCREEN, fields)
                         .build(EditDestinationActivity.this);

--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -191,7 +191,15 @@ public class EditDestinationActivity extends AppCompatActivity {
                     e.printStackTrace();
                 }
                 destination.setIsDay(false);
-                destination.setName(String.valueOf(binding.etDestName.getText()));
+
+                String placeName = place.getName();
+                String inputtedName = String.valueOf(binding.etDestName.getText());
+                if (placeName.equals(inputtedName)){
+                    destination.setName(inputtedName);
+                } else {
+                    destination.setName(inputtedName + "\n" + placeName);
+                }
+
 
                 destination.saveInBackground(new SaveCallback() {
                     @Override

--- a/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
@@ -177,7 +177,6 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
             tvName.setText(name);
 
             if (dest.getIsDay()) {
-                Log.i("DestinationAdapter", name);
                 tvTime.setVisibility(View.GONE);
                 tvName.setTextSize(22);
             } else {

--- a/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
@@ -70,12 +70,14 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
     class ViewHolder extends RecyclerView.ViewHolder {
         TextView tvName;
         TextView tvTime;
+        TextView tvAddress;
 
         public ViewHolder(@NonNull View itemView) {
             super(itemView);
 
             tvName = itemView.findViewById(R.id.tvName);
             tvTime = itemView.findViewById(R.id.tvTime);
+            tvAddress = itemView.findViewById(R.id.tvAddress);
 
             // user can either click to view details or click to edit destination
             itemView.setOnClickListener(new View.OnClickListener() {
@@ -174,7 +176,15 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
 
         public void bind(Destination dest) {
             String name = dest.getName();
-            tvName.setText(name);
+
+            int index = name.indexOf("\n");
+            if (index > 0) {
+                tvName.setText(name.substring(0, index));
+                tvAddress.setText(name.substring(index+1));
+            } else {
+                tvName.setText(name);
+                tvAddress.setVisibility(View.GONE);
+            }
 
             if (dest.getIsDay()) {
                 tvTime.setVisibility(View.GONE);

--- a/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
@@ -171,12 +171,8 @@ public class ItineraryAdapter extends RecyclerView.Adapter<ItineraryAdapter.View
             Date end = itin.getEndDate();
 
             String dates = "";
-            if (start == null && end == null) {
-                dates = "Date undecided";
-            } else if (start != null && end == null) {
-                dates = "Starting " + itin.reformatDate(start);
-            } else if (start == null && end != null){
-                dates = "Ending " + itin.reformatDate(end);
+            if (start.equals(end)) {
+                dates = itin.reformatDate(start);
             } else {
                 dates = itin.reformatDate(start) + " - " + itin.reformatDate(end);
             }

--- a/app/src/main/res/layout/item_destination.xml
+++ b/app/src/main/res/layout/item_destination.xml
@@ -53,6 +53,6 @@
         android:layout_marginTop="3dp"
         android:layout_marginEnd="5dp"
         android:layout_toEndOf="@+id/tvTime"
-        android:textSize="18sp"
+        android:textSize="16sp"
         tools:text="address" />
 </RelativeLayout>

--- a/app/src/main/res/layout/item_destination.xml
+++ b/app/src/main/res/layout/item_destination.xml
@@ -13,7 +13,6 @@
         android:layout_marginStart="18dp"
         android:layout_marginTop="10dp"
         android:layout_marginEnd="5dp"
-        android:layout_marginBottom="5dp"
         android:layout_toEndOf="@+id/tvTime"
         android:textSize="20sp"
         tools:text="National Portrait Gallery" />
@@ -35,7 +34,7 @@
         android:id="@+id/divider"
         android:layout_width="300dp"
         android:layout_height="1dp"
-        android:layout_below="@+id/tvName"
+        android:layout_below="@+id/tvAddress"
         android:layout_alignParentStart="true"
         android:layout_alignParentBottom="false"
         android:layout_centerHorizontal="true"
@@ -43,4 +42,17 @@
         android:layout_marginTop="5dp"
         android:layout_marginEnd="50dp"
         android:background="?android:attr/listDivider" />
+
+    <TextView
+        android:id="@+id/tvAddress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvName"
+        android:layout_alignParentEnd="false"
+        android:layout_marginStart="18dp"
+        android:layout_marginTop="3dp"
+        android:layout_marginEnd="5dp"
+        android:layout_toEndOf="@+id/tvTime"
+        android:textSize="18sp"
+        tools:text="address" />
 </RelativeLayout>


### PR DESCRIPTION
[bugfixes + feature] : fixed errors that appeared when the user inputs one/no dates. also created warning for user when adding a destination that is not open at the given time.

Summary: previously, editing an itinerary with only one given date caused errors when filling the form with default values. This PR fixes it so that the user can still edit and use these itineraries. Also added a feature to check if destinations are open. 

Changes in this PR:
- When creating a new itinerary with only one date, the itinerary will be saved with the same start and end date; the itinerary is a one day trip.
- When saving a new destination, there's a check to see if the location is open at the given time. If it is not open, a Toast is shown and the user should choose a different place/time.
- For personal events, added a description so the user can see both the name of the destination and the location that it's taking place.

Callouts/Follow-ups:
- My solution to the itinerary issue was to set the start and end dates equal to each other. I'm not sure if this is the best solution, as previously the user could set dates such as "Starting on date []" or "Ending on date []". This might be something to look into changing!