### PR TITLE
Loading progress - threads and new library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     implementation 'com.google.android.libraries.places:places:2.4.0'
 
-    implementation 'com.wang.avi:library:2.1.3'
+    implementation 'com.victor:lib:1.0.4'
 
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -2,7 +2,6 @@ package com.example.fbufinalapp;
 
 import android.content.Context;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -23,13 +22,10 @@ import android.view.ViewGroup;
 import com.example.fbufinalapp.adapters.ItineraryAdapter;
 import com.example.fbufinalapp.databinding.FragmentDashboardBinding;
 import com.example.fbufinalapp.models.Itinerary;
-import com.google.android.gms.common.api.ApiException;
-import com.google.android.libraries.places.api.model.Place;
-import com.google.android.libraries.places.api.net.FetchPlaceRequest;
+
 import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
-import com.parse.ParseUser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -137,7 +133,15 @@ public class DashboardFragment extends Fragment {
             }
         });
 
-        new queryTripsAsync().execute();
+        queryTripsAsync queryTrips = new queryTripsAsync();
+        queryTrips.start();
+        try {
+            queryTrips.join();
+        } catch (Exception e){
+            Log.e("Dashboard", String.valueOf(e));
+        }
+
+        binding.avi.hide();
 
         // Allows the user to create new itineraries
         binding.fabNewItin.setOnClickListener(new View.OnClickListener() {
@@ -153,13 +157,23 @@ public class DashboardFragment extends Fragment {
 
     public void fetchTimelineAsync(int page) {
         adapter.clear();
-        new queryTripsAsync().execute();
+        queryTripsAsync queryTrips = new queryTripsAsync();
+        queryTrips.start();
+        try {
+            queryTrips.join();
+        } catch (Exception e){
+            Log.e("Dashboard", String.valueOf(e));
+        }
+
+        binding.avi.hide();
         binding.swipeContainer.setRefreshing(false);
     }
 
-    private class queryTripsAsync extends AsyncTask<Void, Void, Void> {
+    class queryTripsAsync extends Thread{
         @Override
-        protected Void doInBackground(Void... args) {
+        public void run() {
+            binding.avi.show();
+
             ParseQuery<Itinerary> query = ParseQuery.getQuery(Itinerary.class);
             query.include(CommonValues.KEY_USER);
             query.whereEqualTo(CommonValues.KEY_USER, CommonValues.CURRENT_USER);
@@ -177,19 +191,6 @@ public class DashboardFragment extends Fragment {
                     }
                 }
             });
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void result) {
-            binding.avi.hide();
-            super.onPostExecute(result);
-        }
-
-        @Override
-        protected void onPreExecute() {
-            super.onPreExecute();
-            binding.avi.show();
         }
     }
 

--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -80,7 +80,7 @@ public class DashboardFragment extends Fragment {
         binding = FragmentDashboardBinding.inflate(getLayoutInflater(), container, false);
         View view = binding.getRoot();
 
-        binding.avi.show();
+        binding.rotateloading.start();
 
         return view;
     }
@@ -134,6 +134,7 @@ public class DashboardFragment extends Fragment {
         });
 
         queryTripsAsync queryTrips = new queryTripsAsync();
+        binding.rotateloading.start();
         queryTrips.start();
         try {
             queryTrips.join();
@@ -141,7 +142,7 @@ public class DashboardFragment extends Fragment {
             Log.e("Dashboard", String.valueOf(e));
         }
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
 
         // Allows the user to create new itineraries
         binding.fabNewItin.setOnClickListener(new View.OnClickListener() {
@@ -165,14 +166,13 @@ public class DashboardFragment extends Fragment {
             Log.e("Dashboard", String.valueOf(e));
         }
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
         binding.swipeContainer.setRefreshing(false);
     }
 
     class queryTripsAsync extends Thread{
         @Override
         public void run() {
-            binding.avi.show();
 
             ParseQuery<Itinerary> query = ParseQuery.getQuery(Itinerary.class);
             query.include(CommonValues.KEY_USER);

--- a/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
@@ -8,7 +8,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import android.app.ActivityOptions;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.transition.Slide;
 import android.util.Log;
@@ -68,7 +67,15 @@ public class DetailedItineraryActivity extends AppCompatActivity {
 
         itinId = getIntent().getStringExtra("itinId");
 
-        new queryDestinationsAsync().execute();
+        queryDestinationsAsync queryDestinations = new queryDestinationsAsync();
+        queryDestinations.start();
+        try {
+            queryDestinations.join();
+        } catch (Exception e){
+            Log.e("DetailedItinerary", String.valueOf(e));
+        }
+
+        binding.avi.hide();
 
         // Allows the user to create a new destination to add to this itinerary
         binding.fabNewDest.setOnClickListener(new View.OnClickListener() {
@@ -95,9 +102,12 @@ public class DetailedItineraryActivity extends AppCompatActivity {
      * Queries the destinations of the current itinerary in the background. In the meantime, the
      * loading progress symbol is shown.
      */
-    private class queryDestinationsAsync extends AsyncTask<Void, Void, Void> {
+
+    class queryDestinationsAsync extends Thread{
         @Override
-        protected Void doInBackground(Void... args) {
+        public void run() {
+            binding.avi.show();
+
             ParseQuery<Itinerary> queryItinerary = ParseQuery.getQuery(Itinerary.class);
 
             queryItinerary.getInBackground(itinId, (object, e) -> {
@@ -117,19 +127,6 @@ public class DetailedItineraryActivity extends AppCompatActivity {
                     Toast.makeText(DetailedItineraryActivity.this, "Couldn't retrieve itinerary", Toast.LENGTH_SHORT).show();
                 }
             });
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void result) {
-            binding.avi.hide();
-            super.onPostExecute(result);
-        }
-
-        @Override
-        protected void onPreExecute() {
-            super.onPreExecute();
-            binding.avi.show();
         }
     }
 

--- a/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
@@ -68,6 +68,7 @@ public class DetailedItineraryActivity extends AppCompatActivity {
         itinId = getIntent().getStringExtra("itinId");
 
         queryDestinationsAsync queryDestinations = new queryDestinationsAsync();
+        binding.rotateloading.start();
         queryDestinations.start();
         try {
             queryDestinations.join();
@@ -75,7 +76,7 @@ public class DetailedItineraryActivity extends AppCompatActivity {
             Log.e("DetailedItinerary", String.valueOf(e));
         }
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
 
         // Allows the user to create a new destination to add to this itinerary
         binding.fabNewDest.setOnClickListener(new View.OnClickListener() {
@@ -106,7 +107,6 @@ public class DetailedItineraryActivity extends AppCompatActivity {
     class queryDestinationsAsync extends Thread{
         @Override
         public void run() {
-            binding.avi.show();
 
             ParseQuery<Itinerary> queryItinerary = ParseQuery.getQuery(Itinerary.class);
 

--- a/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
@@ -109,8 +109,8 @@ public class DetailedLocationActivity extends AppCompatActivity{
 
         placesClient = Places.createClient(this);
 
-//        new queryPageAsync().execute();
         queryPageAsync queryPage = new queryPageAsync();
+        binding.rotateloading.start();
         queryPage.start();
 
         try {
@@ -120,7 +120,7 @@ public class DetailedLocationActivity extends AppCompatActivity{
             System.out.println(e);
         }
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
 
 
         /**
@@ -203,8 +203,6 @@ public class DetailedLocationActivity extends AppCompatActivity{
     class queryPageAsync extends Thread{
         @Override
         public void run() {
-            binding.avi.show();
-
             populatePage();
             getAllItins();
         }

--- a/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
@@ -5,7 +5,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.transition.Explode;
 import android.util.DisplayMetrics;
@@ -53,7 +52,7 @@ import retrofit2.Response;
 /**
  * Screen to show the user details about a given location. Data obtained from the Google Places SDK.
  */
-public class DetailedLocationActivity extends AppCompatActivity {
+public class DetailedLocationActivity extends AppCompatActivity{
     public static String TAG = "DetailedLocationActivity";
     public static ActivityDetailedLocationBinding binding;
     View layout;
@@ -110,7 +109,19 @@ public class DetailedLocationActivity extends AppCompatActivity {
 
         placesClient = Places.createClient(this);
 
-        new queryPageAsync().execute();
+//        new queryPageAsync().execute();
+        queryPageAsync queryPage = new queryPageAsync();
+        queryPage.start();
+
+        try {
+            queryPage.join();
+        }
+        catch (Exception e) {
+            System.out.println(e);
+        }
+
+        binding.avi.hide();
+
 
         /**
          * the user clicked on the favorites button, so we add/remove it from their favorites
@@ -189,24 +200,13 @@ public class DetailedLocationActivity extends AppCompatActivity {
      * Queries the details of the current location in the background. In the meantime, the
      * loading progress symbol is shown.
      */
-    private class queryPageAsync extends AsyncTask<Void, Void, Void> {
+    class queryPageAsync extends Thread{
         @Override
-        protected Void doInBackground(Void... args) {
-            populatePage(); // obtain place data and fill page
-            getAllItins();
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void result) {
-            super.onPostExecute(result);
-            binding.avi.hide();
-        }
-
-        @Override
-        protected void onPreExecute() {
+        public void run() {
             binding.avi.show();
-            super.onPreExecute();
+
+            populatePage();
+            getAllItins();
         }
     }
 
@@ -385,6 +385,7 @@ public class DetailedLocationActivity extends AppCompatActivity {
      * Obtains a list of all the itineraries the current user has made to display in the popup window
      */
     public void getAllItins(){
+
         ParseQuery<Itinerary> query = ParseQuery.getQuery("Itinerary");
         query.whereEqualTo(CommonValues.KEY_USER, currentUser);
 

--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -3,9 +3,9 @@ package com.example.fbufinalapp;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.transition.Explode;
+import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -70,7 +70,15 @@ public class EditDestinationActivity extends AppCompatActivity {
         itinId = getIntent().getStringExtra("itinId");
 
         // populates page with existing values, if there are any
-        new queryDefaultValues().execute();
+        queryDefaultValues queryDefault = new queryDefaultValues();
+        queryDefault.start();
+        try {
+            queryDefault.join();
+        } catch (Exception e){
+            Log.e("Favorites", String.valueOf(e));
+        }
+
+        binding.avi.hide();
 
         ParseQuery<Itinerary> queryItinerary = ParseQuery.getQuery(Itinerary.class);
 
@@ -204,25 +212,16 @@ public class EditDestinationActivity extends AppCompatActivity {
 
     }
 
-    private class queryDefaultValues extends AsyncTask<Void, Void, Void> {
+    class queryDefaultValues extends Thread{
         @Override
-        protected Void doInBackground(Void... args) {
+        public void run() {
             populateDefaultValues();
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void result) {
-            binding.avi.hide();
-        }
-
-        @Override
-        protected void onPreExecute() {
-            binding.avi.show();
         }
     }
 
     private void populateDefaultValues() {
+        binding.avi.show();
+
         if (getIntent().hasExtra("placeId")){
             String placeId = getIntent().getStringExtra("placeId");
 

--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -71,6 +71,8 @@ public class EditDestinationActivity extends AppCompatActivity {
 
         // populates page with existing values, if there are any
         queryDefaultValues queryDefault = new queryDefaultValues();
+        binding.rotateloading.start();
+
         queryDefault.start();
         try {
             queryDefault.join();
@@ -78,7 +80,7 @@ public class EditDestinationActivity extends AppCompatActivity {
             Log.e("Favorites", String.valueOf(e));
         }
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
 
         ParseQuery<Itinerary> queryItinerary = ParseQuery.getQuery(Itinerary.class);
 
@@ -220,8 +222,6 @@ public class EditDestinationActivity extends AppCompatActivity {
     }
 
     private void populateDefaultValues() {
-        binding.avi.show();
-
         if (getIntent().hasExtra("placeId")){
             String placeId = getIntent().getStringExtra("placeId");
 

--- a/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
@@ -3,7 +3,6 @@ package com.example.fbufinalapp;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.transition.Explode;
 import android.util.Log;
@@ -78,7 +77,15 @@ public class EditItineraryActivity extends AppCompatActivity {
 
         itinId = getIntent().getStringExtra("itinId");
 
-        new queryDefaultValues().execute();
+        queryDefaultValues queryDefaults = new queryDefaultValues();
+        queryDefaults.start();
+        try {
+            queryDefaults.join();
+        } catch (Exception e){
+            Log.e("Favorites", String.valueOf(e));
+        }
+
+        binding.avi.hide();
 
         binding.btFinish.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -101,9 +108,10 @@ public class EditItineraryActivity extends AppCompatActivity {
      * Queries the default values (exists if the user is editing an existing itinerary) of the
      * current itinerary in the background. In the meantime, the loading progress symbol is shown.
      */
-    private class queryDefaultValues extends AsyncTask<Void, Void, Void> {
+    class queryDefaultValues extends Thread{
         @Override
-        protected Void doInBackground(Void... args) {
+        public void run() {
+            binding.avi.show();
             placesClient = Places.createClient(EditItineraryActivity.this);
             if (getIntent().hasExtra("editing")){
                 query = ParseQuery.getQuery("Itinerary");
@@ -138,19 +146,6 @@ public class EditItineraryActivity extends AppCompatActivity {
             } else {
                 getSupportActionBar().setTitle("New Itinerary");
             }
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void result) {
-            binding.avi.hide();
-            super.onPostExecute(result);
-        }
-
-        @Override
-        protected void onPreExecute() {
-            super.onPreExecute();
-            binding.avi.show();
         }
     }
 

--- a/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
@@ -78,6 +78,7 @@ public class EditItineraryActivity extends AppCompatActivity {
         itinId = getIntent().getStringExtra("itinId");
 
         queryDefaultValues queryDefaults = new queryDefaultValues();
+        binding.rotateloading.start();
         queryDefaults.start();
         try {
             queryDefaults.join();
@@ -85,7 +86,7 @@ public class EditItineraryActivity extends AppCompatActivity {
             Log.e("Favorites", String.valueOf(e));
         }
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
 
         binding.btFinish.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -111,7 +112,6 @@ public class EditItineraryActivity extends AppCompatActivity {
     class queryDefaultValues extends Thread{
         @Override
         public void run() {
-            binding.avi.show();
             placesClient = Places.createClient(EditItineraryActivity.this);
             if (getIntent().hasExtra("editing")){
                 query = ParseQuery.getQuery("Itinerary");

--- a/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
@@ -1,7 +1,6 @@
 package com.example.fbufinalapp;
 
 import android.content.Context;
-import android.os.AsyncTask;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -96,12 +95,30 @@ public class FavoritesFragment extends Fragment {
             }
         });
 
-        new queryFavoritesAsync().execute();
+        queryFavoritesAsync queryFavorites = new queryFavoritesAsync();
+        queryFavorites.start();
+        try {
+            queryFavorites.join();
+        } catch (Exception e){
+            Log.e("Favorites", String.valueOf(e));
+        }
+
+        binding.avi.hide();
+        Log.i("Favorites", "finished async" + binding.avi.getVisibility());
+
     }
 
     public void fetchTimelineAsync(int page) {
         favAdapter.clear();
-        new queryFavoritesAsync().execute();
+        queryFavoritesAsync queryFavorites = new queryFavoritesAsync();
+        queryFavorites.start();
+        try {
+            queryFavorites.join();
+        } catch (Exception e){
+            Log.e("Favorites", String.valueOf(e));
+        }
+
+        binding.avi.hide();
         binding.swipeContainer.setRefreshing(false);
     }
 
@@ -109,9 +126,11 @@ public class FavoritesFragment extends Fragment {
      * Queries the favorite locations of the current user in the background. In the meantime, the
      * loading progress symbol is shown.
      */
-    private class queryFavoritesAsync extends AsyncTask<Void, Void, Void> {
+    class queryFavoritesAsync extends Thread{
         @Override
-        protected Void doInBackground(Void... args) {
+        public void run() {
+            binding.avi.show();
+
             for (Object fav: currentUser.getList(CommonValues.KEY_FAVORITES)) {
                 String placeId = String.valueOf(fav);
 
@@ -128,19 +147,7 @@ public class FavoritesFragment extends Fragment {
                     }
                 });
             }
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void result) {
-            binding.avi.hide();
-            binding.rvFavorites.setVisibility(View.VISIBLE);
-        }
-
-        @Override
-        protected void onPreExecute() {
-            binding.rvFavorites.setVisibility(View.INVISIBLE);
-            binding.avi.show();
+            Log.i("Favorites", "finished query" + String.valueOf(binding.avi.getVisibility() == View.VISIBLE));
         }
     }
 

--- a/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
@@ -65,8 +65,6 @@ public class FavoritesFragment extends Fragment {
         binding = FragmentFavoritesBinding.inflate(getLayoutInflater(), container, false);
         View view = binding.getRoot();
 
-        binding.avi.show();
-
         return view;
     }
 
@@ -96,6 +94,7 @@ public class FavoritesFragment extends Fragment {
         });
 
         queryFavoritesAsync queryFavorites = new queryFavoritesAsync();
+        binding.rotateloading.start();
         queryFavorites.start();
         try {
             queryFavorites.join();
@@ -103,14 +102,14 @@ public class FavoritesFragment extends Fragment {
             Log.e("Favorites", String.valueOf(e));
         }
 
-        binding.avi.hide();
-        Log.i("Favorites", "finished async" + binding.avi.getVisibility());
+        binding.rotateloading.stop();
 
     }
 
     public void fetchTimelineAsync(int page) {
         favAdapter.clear();
         queryFavoritesAsync queryFavorites = new queryFavoritesAsync();
+        binding.rotateloading.start();
         queryFavorites.start();
         try {
             queryFavorites.join();
@@ -118,7 +117,7 @@ public class FavoritesFragment extends Fragment {
             Log.e("Favorites", String.valueOf(e));
         }
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
         binding.swipeContainer.setRefreshing(false);
     }
 
@@ -129,8 +128,6 @@ public class FavoritesFragment extends Fragment {
     class queryFavoritesAsync extends Thread{
         @Override
         public void run() {
-            binding.avi.show();
-
             for (Object fav: currentUser.getList(CommonValues.KEY_FAVORITES)) {
                 String placeId = String.valueOf(fav);
 
@@ -147,7 +144,6 @@ public class FavoritesFragment extends Fragment {
                     }
                 });
             }
-            Log.i("Favorites", "finished query" + String.valueOf(binding.avi.getVisibility() == View.VISIBLE));
         }
     }
 

--- a/app/src/main/java/com/example/fbufinalapp/SearchFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/SearchFragment.java
@@ -25,7 +25,6 @@ import com.google.android.libraries.places.api.model.AutocompletePrediction;
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken;
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest;
 import com.google.android.libraries.places.api.net.PlacesClient;
-import com.wang.avi.AVLoadingIndicatorView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +65,7 @@ public class SearchFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        binding.avi.show();
+        binding.rotateloading.start();
     }
 
     @Override
@@ -77,7 +76,7 @@ public class SearchFragment extends Fragment {
         binding = FragmentSearchBinding.inflate(getLayoutInflater(), container, false);
         View view = binding.getRoot();
 
-        binding.avi.show();
+        binding.rotateloading.start();
 
         return view;
     }
@@ -96,7 +95,7 @@ public class SearchFragment extends Fragment {
 
         binding.etSearch.addTextChangedListener(searchListener);
 
-        binding.avi.hide();
+        binding.rotateloading.stop();
 
         placesClient = Places.createClient(context);
     }

--- a/app/src/main/res/layout/activity_detailed_itinerary.xml
+++ b/app/src/main/res/layout/activity_detailed_itinerary.xml
@@ -34,15 +34,13 @@
             android:padding="10dp" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <com.wang.avi.AVLoadingIndicatorView
-        android:id="@+id/avi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        style="@style/AVLoadingIndicatorView"
-        app:indicatorName="BallClipRotateIndicator"
-        app:indicatorColor="@color/brown"
-        />
+    <com.victor.loading.rotate.RotateLoading
+        android:id="@+id/rotateloading"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:loading_width="5dp"
+        app:loading_color="@color/brown"
+        android:layout_centerInParent="true"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabNewDest"

--- a/app/src/main/res/layout/activity_detailed_location.xml
+++ b/app/src/main/res/layout/activity_detailed_location.xml
@@ -110,16 +110,6 @@
         app:backgroundTint="@color/brown_light"
         app:srcCompat="@drawable/ic_favorite" />
 
-    <com.wang.avi.AVLoadingIndicatorView
-        android:id="@+id/avi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        style="@style/AVLoadingIndicatorView"
-        app:indicatorName="BallClipRotateIndicator"
-        app:indicatorColor="@color/brown"
-        />
-
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabAddToItin"
         android:layout_width="wrap_content"
@@ -172,4 +162,11 @@
         tools:text="Sunny, with a high near 85. Northeast wind around 7 mph." />
 
 
+    <com.victor.loading.rotate.RotateLoading
+        android:id="@+id/rotateloading"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:loading_width="5dp"
+        app:loading_color="@color/brown"
+        android:layout_centerInParent="true"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_edit_destination.xml
+++ b/app/src/main/res/layout/activity_edit_destination.xml
@@ -167,14 +167,12 @@
         android:layout_toEndOf="@+id/tvDestName"
         android:ems="10" />
 
-    <com.wang.avi.AVLoadingIndicatorView
-        android:id="@+id/avi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        style="@style/AVLoadingIndicatorView"
-        app:indicatorName="BallClipRotateIndicator"
-        app:indicatorColor="@color/brown"
-        />
+    <com.victor.loading.rotate.RotateLoading
+        android:id="@+id/rotateloading"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:loading_width="5dp"
+        app:loading_color="@color/brown"
+        android:layout_centerInParent="true"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_edit_itinerary.xml
+++ b/app/src/main/res/layout/activity_edit_itinerary.xml
@@ -147,14 +147,12 @@
         android:layout_marginTop="300dp"
         android:text="Save Trip" />
 
-    <com.wang.avi.AVLoadingIndicatorView
-        android:id="@+id/avi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        style="@style/AVLoadingIndicatorView"
-        app:indicatorName="BallClipRotateIndicator"
-        app:indicatorColor="@color/brown"
-        />
+    <com.victor.loading.rotate.RotateLoading
+        android:id="@+id/rotateloading"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:loading_width="5dp"
+        app:loading_color="@color/brown"
+        android:layout_centerInParent="true"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -34,15 +34,13 @@
             android:padding="8dp" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <com.wang.avi.AVLoadingIndicatorView
-        android:id="@+id/avi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        style="@style/AVLoadingIndicatorView"
-        app:indicatorName="BallClipRotateIndicator"
-        app:indicatorColor="@color/brown"
-        />
+    <com.victor.loading.rotate.RotateLoading
+        android:id="@+id/rotateloading"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:loading_width="5dp"
+        app:loading_color="@color/brown"
+        android:layout_centerInParent="true"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabNewItin"

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -33,15 +33,13 @@
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 
-    <com.wang.avi.AVLoadingIndicatorView
-        android:id="@+id/avi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        style="@style/AVLoadingIndicatorView"
-        app:indicatorName="BallClipRotateIndicator"
-        app:indicatorColor="@color/brown"
-    />
+    <com.victor.loading.rotate.RotateLoading
+        android:id="@+id/rotateloading"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:loading_width="5dp"
+        app:loading_color="@color/brown"
+        android:layout_centerInParent="true"/>
 
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -47,14 +47,12 @@
         android:paddingTop="10dp"
         android:paddingEnd="12dp" />
 
-    <com.wang.avi.AVLoadingIndicatorView
-        android:id="@+id/avi"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        style="@style/AVLoadingIndicatorView"
-        app:indicatorName="BallClipRotateIndicator"
-        app:indicatorColor="@color/brown"
-        />
+    <com.victor.loading.rotate.RotateLoading
+        android:id="@+id/rotateloading"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:loading_width="5dp"
+        app:loading_color="@color/brown"
+        android:layout_centerInParent="true"/>
 
 </RelativeLayout>


### PR DESCRIPTION
[bugfix] : changed progress spinner library to a more updated one

Summary: previous library being used for the progress spinners was deprecated and no longer maintained, so spinners would not always appear. In this PR, I changed the library to one that is more up to date so they now appear. Also changed AsyncTasks to threads.

Changes in this PR: 
- Replaced AsyncTask with threads for loading pages in background
- Replaced the previous spinner library with a new one (link [here](https://github.com/yankai-victor/Loading/wiki/RotateLoading))

Callouts/Follow-up:
- there's still a slight delay between the progress spinner disappearing and the activity being populated; I think this has to do with how I'm calling multiple methods from within the thread. Should look into this!