### PR TITLE
fixed guest account errors

### DIFF
--- a/app/src/main/java/com/example/fbufinalapp/CommonValues.java
+++ b/app/src/main/java/com/example/fbufinalapp/CommonValues.java
@@ -1,7 +1,5 @@
 package com.example.fbufinalapp;
 
-import com.parse.ParseUser;
-
 public class CommonValues {
     // Destination model values =========
     public static String KEY_DESCRIPTION_DESTINATION = "notes";
@@ -23,5 +21,5 @@ public class CommonValues {
     // User model values ================
     public static String KEY_ITINERARY_USER = "itineraries";
     public static String KEY_FAVORITES = "favorites";
-    public static ParseUser CURRENT_USER = ParseUser.getCurrentUser();
+    public static String KEY_USERNAME = "username";
 }

--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -26,6 +26,7 @@ import com.example.fbufinalapp.models.Itinerary;
 import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
+import com.parse.ParseUser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -176,7 +177,7 @@ public class DashboardFragment extends Fragment {
 
             ParseQuery<Itinerary> query = ParseQuery.getQuery(Itinerary.class);
             query.include(CommonValues.KEY_USER);
-            query.whereEqualTo(CommonValues.KEY_USER, CommonValues.CURRENT_USER);
+            query.whereEqualTo(CommonValues.KEY_USER, ParseUser.getCurrentUser());
 
             // order posts by creation date (newest first)
             query.addDescendingOrder("createdAt");

--- a/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedLocationActivity.java
@@ -89,7 +89,7 @@ public class DetailedLocationActivity extends AppCompatActivity{
         ratingBar = findViewById(R.id.ratingBar);
         fabAddToFav = findViewById(R.id.fabAddToFav);
 
-        currentUser = CommonValues.CURRENT_USER;
+        currentUser = ParseUser.getCurrentUser();
         getWindow().setEnterTransition(new Explode());
 
         // builds a popup window; to be used when the user adds the current location to an itinerary

--- a/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditDestinationActivity.java
@@ -283,6 +283,7 @@ public class EditDestinationActivity extends AppCompatActivity {
             }
         } else {
             tvLocation.setOnFocusChangeListener(focusListener);
+            getSupportActionBar().setTitle("New Destination");
         }
     }
 

--- a/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
@@ -193,7 +193,7 @@ public class EditItineraryActivity extends AppCompatActivity {
             }
             itin.setTitle(title);
 
-            ParseUser currentUser = CommonValues.CURRENT_USER;
+            ParseUser currentUser = ParseUser.getCurrentUser();
             itin.setAuthor(currentUser);
 
             itin.setDescription(notes);

--- a/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/FavoritesFragment.java
@@ -74,7 +74,7 @@ public class FavoritesFragment extends Fragment {
 
         rvFavorites = view.findViewById(R.id.rvFavorites);
 
-        currentUser = CommonValues.CURRENT_USER;
+        currentUser = ParseUser.getCurrentUser();
 
         placesClient = Places.createClient(context);
         placeFields = Arrays.asList(Place.Field.ID, Place.Field.NAME, Place.Field.ADDRESS);

--- a/app/src/main/java/com/example/fbufinalapp/LoginActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/LoginActivity.java
@@ -34,12 +34,6 @@ public class LoginActivity extends AppCompatActivity {
         tvUsername = findViewById(R.id.tvUsername);
         tvPassword = findViewById(R.id.tvPassword);
 
-        ParseUser currentUser = CommonValues.CURRENT_USER;
-        if (currentUser != null) {
-            Intent i = new Intent(LoginActivity.this, MainActivity.class);
-            startActivity(i);
-        }
-
         binding.btLogIn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/java/com/example/fbufinalapp/MainActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/MainActivity.java
@@ -15,6 +15,9 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.parse.ParseException;
+import com.parse.ParseObject;
+import com.parse.ParseQuery;
 import com.parse.ParseUser;
 
 import java.util.ArrayList;
@@ -33,7 +36,7 @@ public class MainActivity extends AppCompatActivity {
         View view = binding.getRoot();
         setContentView(view);
 
-        if (CommonValues.CURRENT_USER == null){
+        if (ParseUser.getCurrentUser() == null){
             setGuestUser();
         }
 
@@ -89,7 +92,8 @@ public class MainActivity extends AppCompatActivity {
 
     public void setGuestUser(){
         ParseUser user = new ParseUser();
-        user.setUsername("Guest");
+
+        user.setUsername("Guest #" + findNumGuests());
         user.setPassword("default");
         user.put(CommonValues.KEY_FAVORITES, new ArrayList<>());
         user.put(CommonValues.KEY_ITINERARY_USER, new ArrayList<>());
@@ -101,6 +105,20 @@ public class MainActivity extends AppCompatActivity {
                 Log.e("SignUp Failed", String.valueOf(e));
             }
         });
+    }
+
+    public int findNumGuests(){
+        int count = 0;
+        ParseQuery<ParseUser> query = ParseUser.getQuery();
+        query.whereStartsWith(CommonValues.KEY_USERNAME, "Guest #");
+
+        try {
+            count = query.count();
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+
+        return count;
     }
 
 }

--- a/app/src/main/java/com/example/fbufinalapp/ProfileFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/ProfileFragment.java
@@ -47,7 +47,7 @@ public class ProfileFragment extends Fragment {
         binding = FragmentProfileBinding.inflate(getLayoutInflater(), container, false);
         View view = binding.getRoot();
 
-        currentUser = CommonValues.CURRENT_USER;
+        currentUser = ParseUser.getCurrentUser();
         newUser = (currentUser.getEmail() == null);
 
         return view;

--- a/app/src/main/java/com/example/fbufinalapp/SignUpActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/SignUpActivity.java
@@ -34,7 +34,7 @@ public class SignUpActivity extends AppCompatActivity {
         View view = binding.getRoot();
         setContentView(view);
 
-        currentUser = CommonValues.CURRENT_USER;
+        currentUser = ParseUser.getCurrentUser();
 
         getSupportActionBar().setTitle("Register");
 

--- a/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/ItineraryAdapter.java
@@ -132,7 +132,7 @@ public class ItineraryAdapter extends RecyclerView.Adapter<ItineraryAdapter.View
                     for (Itinerary i : itins){
                         itinIds.add(i.getObjectId());
                     }
-                    currentUser = CommonValues.CURRENT_USER;
+                    currentUser = ParseUser.getCurrentUser();
                     currentUser.put(CommonValues.KEY_ITINERARY_USER, itinIds);
 
                     currentUser.saveInBackground(e -> {

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -58,10 +58,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/tvEmail"
-        android:layout_alignParentBottom="false"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="20dp"
-        android:layout_marginBottom="217dp"
         android:text="Sign Up" />
 
     <TextView
@@ -69,10 +67,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/btSignUp"
-        android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="10dp"
-        android:layout_marginBottom="235dp"
         android:text="Already have an account? Log in!" />
 
 


### PR DESCRIPTION
[bugfix] : resolves issues where multiple guest accounts caused the app to crash

Summary: previously, if the user had a guest account and made a new account, the next guest account would crash the app because it had the same username as an existing account. In this PR, I add "tags" to new guest accounts to differentiate them.

Changes in this PR:
- When the user enters the app in a guest account, the number of guest accounts is calculated so they can be assigned a "tag" (i.e. Guest#4)
- Removed CURRENT_USER from CommonValues, as it was causing issues when its value didn't update at the same time as the current user. Caused null pointer errors as the user logged out/signed up.

Callouts/Follow-up:
- It may be a nice idea to include tags for all accounts, so regardless if they are a guest or not, users can share usernames and be differentiated by tags (like in Riot lol). 