### PR TITLE
Share

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <application
         android:name=".ParseApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <application
         android:name=".ParseApplication"

--- a/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
+++ b/app/src/main/java/com/example/fbufinalapp/DashboardFragment.java
@@ -18,7 +18,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
 import com.example.fbufinalapp.adapters.ItineraryAdapter;
 import com.example.fbufinalapp.databinding.FragmentDashboardBinding;
@@ -94,6 +93,7 @@ public class DashboardFragment extends Fragment {
         this.menu = menu;
 
         menu.findItem(R.id.action_add_person).setVisible(false);
+        menu.findItem(R.id.action_share).setVisible(false);
     }
 
     /**

--- a/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
@@ -9,12 +9,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import android.app.ActivityOptions;
 import android.content.Intent;
-import android.graphics.Canvas;
-import android.graphics.Paint;
-import android.graphics.pdf.PdfDocument;
 import android.os.Bundle;
-import android.os.Environment;
-import android.os.Parcelable;
 import android.transition.Slide;
 import android.util.Log;
 import android.view.Menu;
@@ -30,9 +25,6 @@ import com.parse.FindCallback;
 import com.parse.ParseException;
 import com.parse.ParseQuery;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/DetailedItineraryActivity.java
@@ -225,34 +225,7 @@ public class DetailedItineraryActivity extends AppCompatActivity {
     }
 
     public void shareItinerary(){
-        int pageHeight = 1120;
-        int pageWidth = 792;
-
-        PdfDocument document = new PdfDocument();
-
-        Paint paint = new Paint();
-        Paint textFormat = new Paint();
-
-        PdfDocument.PageInfo pageInfo = new PdfDocument.PageInfo.Builder(pageWidth, pageHeight, 1).create();
-
-
-        PdfDocument.Page page = document.startPage(pageInfo);
-        Canvas canvas = page.getCanvas();
-
-        textFormat.setTextSize(28);
-        textFormat.setTextAlign(Paint.Align.CENTER);
-        canvas.drawText(currentItinerary.getTitle(), 100, 125, textFormat);
-
-        textFormat.setTextSize(20);
-        textFormat.setTextAlign(Paint.Align.LEFT);
         String destins = getPDFDestinations();
-        int yLoc = 175;
-        for (String i : destins.split("\n")) {
-            canvas.drawText(i, 100, yLoc, textFormat);
-            yLoc += 25;
-        }
-
-        document.finishPage(page);
 
         Intent shareIntent = new Intent();
         shareIntent.setAction(Intent.ACTION_SEND);
@@ -261,7 +234,6 @@ public class DetailedItineraryActivity extends AppCompatActivity {
         shareIntent.setType("application/pdf");
         startActivity(Intent.createChooser(shareIntent, "Share itinerary to..."));
 
-        document.close();
     }
 
     public String getPDFDestinations(){

--- a/app/src/main/java/com/example/fbufinalapp/MainActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/MainActivity.java
@@ -16,7 +16,6 @@ import android.widget.Toast;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.parse.ParseException;
-import com.parse.ParseObject;
 import com.parse.ParseQuery;
 import com.parse.ParseUser;
 

--- a/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
+++ b/app/src/main/java/com/example/fbufinalapp/adapters/DestinationAdapter.java
@@ -64,6 +64,10 @@ public class DestinationAdapter extends RecyclerView.Adapter<DestinationAdapter.
         return destinations.size();
     }
 
+    public List<Destination> getItems(){
+        return destinations;
+    }
+
     public void clear() {
         destinations.clear();
         notifyDataSetChanged();

--- a/app/src/main/java/com/example/fbufinalapp/models/Destination.java
+++ b/app/src/main/java/com/example/fbufinalapp/models/Destination.java
@@ -71,7 +71,8 @@ public class Destination extends ParseObject{
 
     public void setItinerary(Itinerary itin) { put(CommonValues.KEY_ITINERARY_DESTINATION, itin); }
 
-    public String reformatTime(Date time){
+    public String reformatTime(){
+        Date time = getDate();
         String pattern = "hh:mm a";
         SimpleDateFormat simpleDateFormat =new SimpleDateFormat(pattern);
 

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/app/src/main/res/menu/menu_bar.xml
+++ b/app/src/main/res/menu/menu_bar.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_share"
+        android:icon="@drawable/ic_share"
+        android:iconTint="@color/white"
+        android:title="SHARE"
+        app:showAsAction="always" />
+    <item
         android:id="@+id/action_add_person"
         android:icon="@drawable/ic_add_person"
         android:iconTint="@color/white"


### PR DESCRIPTION
[task] : users can now share their itinerary as text outside their app

Summary: previously, users could only share their itineraries with users within the app. Now, they can export itineraries as text to other apps, such as messages or Google Drive.

Changes in this PR:
- Added new share button to itinerary menu bar
- Clicking new share button opens the Android Sharesheet so the user can pick apps to share with