### PR TITLE
quick dates fix

### DIFF
--- a/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
+++ b/app/src/main/java/com/example/fbufinalapp/EditItineraryActivity.java
@@ -206,17 +206,17 @@ public class EditItineraryActivity extends AppCompatActivity {
 
             List<String> destinations;
 
-            if (editing){
-                destinations = removeDates(start, end);
-            } else {
-                destinations = new ArrayList<>();
-            }
-
             Calendar cStart = Calendar.getInstance();
             cStart.setTime(start);
             Calendar cEnd = Calendar.getInstance();
             cEnd.setTime(end);
             cEnd.add(Calendar.DATE, 1);
+
+            if (editing){
+                destinations = removeDates(start, cEnd.getTime());
+            } else {
+                destinations = new ArrayList<>();
+            }
 
             String pattern = "MMMM dd, yyyy";
             SimpleDateFormat dateFormat = new SimpleDateFormat(pattern);


### PR DESCRIPTION
[bugfix] : fixed date issue when editing itineraries

Summary: previously, if the user shortened the itinerary's dates so the new end date was before the old one, some destinations would be deleted. This PR fixes this so these won't be removed anymore.

Changes in this PR:
- Added one to the end date before removing dates, so destinations occurring on the new end date won't be removed.